### PR TITLE
correct logo position

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -12,7 +12,6 @@ book:
       Imago | UKRI Imagery Data Service
     right: |
       This book was built with <a href="https://quarto.org/">Quarto</a>.
-  cover-image: assets/Imago-logo.png
   favicon: assets/Imago-logo.png
   repo-url: https://github.com/Imago-SDRUK/Imago-training
   repo-branch: main

--- a/index.qmd
+++ b/index.qmd
@@ -1,3 +1,5 @@
+<img src="assets/Imago-logo.png" alt="Imago Logo" style="float:right; width: 150px;"/>
+
 # Welcome {.unnumbered}
 
 ## Imago for evidence-based policy


### PR DESCRIPTION
# Pull Request

## Description
This pull request makes a small adjustment to the way the Imago logo is displayed in the documentation. The change removes the `cover-image` configuration from `_quarto.yml` and instead adds the logo directly to the top of the `index.qmd` file for better control over its appearance.

## Type of change
Changes in two files were made:
  * Removed the `cover-image` property from `_quarto.yml` to prevent automatic cover image rendering.
  * Added an inline `<img>` tag to `index.qmd` to display the Imago logo at the top right of the homepage with custom styling. Put the logo to the correct location, next to the welcome heading