### PR TITLE
Update publish.yml to avoid artefacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,12 @@
 on:
   workflow_dispatch:
   push:
-    branches: [main, auto_render]
+    branches: [main, 15-failed-auto-renders-creating-orphan-artefacts ]
 
+concurrency:
+  group: pages
+  cancel-in-progress: false
+  
 name: Quarto Publish
 
 permissions:


### PR DESCRIPTION
# Pull Request

## Description

Fixes repeated deployment failures caused by orphaned `github-pages` artifacts accumulating across re-runs.

Adds a `concurrency` group to `publish.yml` so that only one deployment can run at a time. New runs will queue rather than stack, preventing multiple artifacts from being created for the same workflow run.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added labels to the PR

## Related Issues

Fixes #15

---

## 🌈 Would you like to be added to the contributors list in the README?

If you would like to be acknowledged in the contributors table, please comment after your PR is merged:

```
@all-contributors please add @your-username for code, doc, etc.
```
Replace `@your-username` and the contribution types as appropriate.  
See the [emoji key](https://allcontributors.org/docs/en/emoji-key) for available contribution types.